### PR TITLE
Extend markdown tokens and render them

### DIFF
--- a/docs/api/renderer.md
+++ b/docs/api/renderer.md
@@ -509,6 +509,54 @@ const contentWithToc = addTableOfContents(content, toc);
 ```
 
 ### Custom Content Processing
+### Svelte Markdown: custom and overridden token components
+
+Render markdown in Svelte with custom token components via `extensionComponents` and optional `unknownToken` fallback:
+
+```svelte
+<script lang="ts">
+  import { Markdown, Marked } from '@markpage/svelte';
+  import MathInline from '$lib/components/MathInline.svelte';
+  import MathBlock from '$lib/components/MathBlock.svelte';
+
+  function mathExtension() {
+    return {
+      extensions: [
+        { name: 'math_block', level: 'block', start: (s: string) => s.indexOf('$$') ?? undefined, tokenizer(src: string) {
+          if (!src.startsWith('$$')) return; const end = src.indexOf('$$', 2); if (end === -1) return; const raw = src.slice(0, end + 2); const text = src.slice(2, end).trim(); return { type: 'math_block', raw, text } as any; } },
+        { name: 'math_inline', level: 'inline', start: (s: string) => s.indexOf('$') ?? undefined, tokenizer(src: string) {
+          if (src.startsWith('$$')) return; if (!src.startsWith('$')) return; const end = src.indexOf('$', 1); if (end === -1) return; const raw = src.slice(0, end + 1); const text = src.slice(1, end).trim(); return { type: 'math_inline', raw, text } as any; } }
+      ]
+    };
+  }
+
+  const markedInstance = new Marked();
+  markedInstance.use(mathExtension());
+
+  const extensionComponents = new Map<string, any>([
+    ['math_inline', MathInline],
+    ['math_block', MathBlock]
+  ]);
+
+  const source = 'Here is inline $a+b=c$ and a block:\n\n$$\nE=mc^2\n$$';
+</script>
+
+<Markdown {source} {markedInstance} {extensionComponents} />
+```
+
+Override a built-in token (e.g., `codespan`):
+
+```svelte
+<script lang="ts">
+  import { Markdown } from '@markpage/svelte';
+  import OverrideCodeSpan from '$lib/components/OverrideCodeSpan.svelte';
+
+  const extensionComponents = new Map<string, any>([['codespan', OverrideCodeSpan]]);
+  const source = 'Inline `code` here';
+</script>
+
+<Markdown {source} {extensionComponents} />
+```
 
 ```typescript
 import { loadContent } from 'markpage/renderer';

--- a/docs/proposals/token-and-component-extensibility.md
+++ b/docs/proposals/token-and-component-extensibility.md
@@ -103,10 +103,11 @@ await buildPages('./docs', {
 <Markdown {source} {extensionComponents} />
 ```
 
-#### Minimal Svelte changes
-- `Markdown.svelte` and `MarkdownToken.svelte`:
-  - Accept `extensionComponents?: Map<string, any>` and optional `unknownToken?: (token:any)=>any` via props.
-  - In `MarkdownToken.svelte`, resolve component with the precedence defined above.
+#### Implemented Svelte changes
+- `Markdown.svelte`, `MarkdownTokens.svelte`, `MarkdownToken.svelte` now support:
+  - `extensionComponents?: Map<string, any>` — custom token type to Svelte component mapping
+  - `unknownToken?: (token: any) => any` — optional fallback component factory
+  - Resolution order: `extensionComponents` → built-ins → `unknownToken`
 
 - #### API Summary
 - Core
@@ -116,10 +117,9 @@ await buildPages('./docs', {
   - `Markdown` props: `components?: Map<ComponentName, any>`, `extensionComponents?: Map<string, any>`, `unknownToken?: (token:any)=>any`
 
 #### Testing
-- Add tests in `@markpage/tests` that:
-  - Verify tokens `math_inline` and `math_block` appear from the plugin
-  - Verify Svelte renderer uses `extensionComponents` over built-ins
-  - Ensure no regressions for built-in tokens and `<Component />` tags
+- Added tests in `@markpage/tests`:
+  - `svelte-markdown-extension.test.ts` validates `math_inline` and `math_block` custom tokens render via `extensionComponents`
+  - `svelte-markdown-override.test.ts` verifies overriding a built-in token (`codespan`) via `extensionComponents`
 
 #### Open Questions
 - Should we ship default math components behind an optional peer dep (`katex`)? Proposal: provide components in `@markpage/plugin-math-svelte` to avoid forcing a renderer choice.

--- a/packages/markpage-svelte/src/lib/markdown/Markdown.svelte
+++ b/packages/markpage-svelte/src/lib/markdown/Markdown.svelte
@@ -7,10 +7,14 @@
     source,
     components = new Map<ComponentName, any>(),
     markedInstance,
+    extensionComponents = new Map<string, any>(),
+    unknownToken,
   }: {
     source: string;
     components?: Map<ComponentName, any>;
     markedInstance?: any;
+    extensionComponents?: Map<string, any>;
+    unknownToken?: ((token: any) => any) | undefined;
   } = $props();
 
   let tokens = $derived.by(() => {
@@ -21,5 +25,5 @@
 </script>
 
 <div class="markpage">
-  <MarkdownTokens {tokens} {components} />
+  <MarkdownTokens {tokens} {components} {extensionComponents} {unknownToken} />
 </div>

--- a/packages/markpage-svelte/src/lib/markdown/MarkdownTokens.svelte
+++ b/packages/markpage-svelte/src/lib/markdown/MarkdownTokens.svelte
@@ -6,12 +6,18 @@
   let {
     tokens,
     components,
-  }: { tokens: Token[] | null; components?: Map<ComponentName, any> } =
-    $props();
+    extensionComponents = new Map<string, any>(),
+    unknownToken,
+  }: {
+    tokens: Token[] | null;
+    components?: Map<ComponentName, any>;
+    extensionComponents?: Map<string, any>;
+    unknownToken?: ((token: any) => any) | undefined;
+  } = $props();
 </script>
 
 {#if tokens}
   {#each tokens as token}
-    <MarkdownToken {token} {components} />
+    <MarkdownToken {token} {components} {extensionComponents} {unknownToken} />
   {/each}
 {/if}

--- a/packages/tests/renderer/components/MathBlock.svelte
+++ b/packages/tests/renderer/components/MathBlock.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { token }: { token: { text: string } } = $props();
+</script>
+
+<div data-math="block">{token.text}</div>
+

--- a/packages/tests/renderer/components/MathInline.svelte
+++ b/packages/tests/renderer/components/MathInline.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { token }: { token: { text: string } } = $props();
+</script>
+
+<span data-math="inline">{token.text}</span>
+

--- a/packages/tests/renderer/components/OverrideCodeSpan.svelte
+++ b/packages/tests/renderer/components/OverrideCodeSpan.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { token }: { token: { text: string } } = $props();
+</script>
+
+<code data-overridden="true">{token.text}</code>
+

--- a/packages/tests/renderer/svelte-markdown-extension.test.ts
+++ b/packages/tests/renderer/svelte-markdown-extension.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import { Markdown, Marked } from '@markpage/svelte';
+import MathInline from './components/MathInline.svelte';
+import MathBlock from './components/MathBlock.svelte';
 
 // Simple marked extension to detect $...$ (inline) and $$...$$ (block)
 function mathExtension() {
@@ -43,22 +45,7 @@ function mathExtension() {
   };
 }
 
-// Minimal components for testing: render predictable HTML
-// MathInline.svelte
-const MathInline = {
-  render: ({ props }: any) => {
-    const { token } = props;
-    return { html: `<span data-math="inline">${token.text}</span>` };
-  }
-} as any;
-
-// MathBlock.svelte
-const MathBlock = {
-  render: ({ props }: any) => {
-    const { token } = props;
-    return { html: `<div data-math="block">${token.text}</div>` };
-  }
-} as any;
+// Using Svelte components from the test components directory
 
 describe('Svelte Markdown extensionComponents rendering', () => {
   it('renders custom math tokens using extensionComponents', async () => {

--- a/packages/tests/renderer/svelte-markdown-extension.test.ts
+++ b/packages/tests/renderer/svelte-markdown-extension.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { Markdown, Marked } from '@markpage/svelte';
+
+// Simple marked extension to detect $...$ (inline) and $$...$$ (block)
+function mathExtension() {
+  return {
+    extensions: [
+      {
+        name: 'math_block',
+        level: 'block' as const,
+        start(src: string) {
+          const i = src.indexOf('$$');
+          return i < 0 ? undefined : i;
+        },
+        tokenizer(src: string) {
+          if (!src.startsWith('$$')) return;
+          const end = src.indexOf('$$', 2);
+          if (end === -1) return;
+          const raw = src.slice(0, end + 2);
+          const text = src.slice(2, end).trim();
+          return { type: 'math_block', raw, text } as any;
+        }
+      },
+      {
+        name: 'math_inline',
+        level: 'inline' as const,
+        start(src: string) {
+          const i = src.indexOf('$');
+          return i < 0 ? undefined : i;
+        },
+        tokenizer(src: string) {
+          if (src.startsWith('$$')) return; // let block handle
+          if (!src.startsWith('$')) return;
+          const end = src.indexOf('$', 1);
+          if (end === -1) return;
+          const raw = src.slice(0, end + 1);
+          const text = src.slice(1, end).trim();
+          return { type: 'math_inline', raw, text } as any;
+        }
+      }
+    ]
+  };
+}
+
+// Minimal components for testing: render predictable HTML
+// MathInline.svelte
+const MathInline = {
+  render: ({ props }: any) => {
+    const { token } = props;
+    return { html: `<span data-math="inline">${token.text}</span>` };
+  }
+} as any;
+
+// MathBlock.svelte
+const MathBlock = {
+  render: ({ props }: any) => {
+    const { token } = props;
+    return { html: `<div data-math="block">${token.text}</div>` };
+  }
+} as any;
+
+describe('Svelte Markdown extensionComponents rendering', () => {
+  it('renders custom math tokens using extensionComponents', async () => {
+    const markedInstance = new Marked();
+    markedInstance.use(mathExtension());
+
+    const extensionComponents = new Map<string, any>([
+      ['math_inline', MathInline],
+      ['math_block', MathBlock]
+    ]);
+
+    const source = `
+Here is inline math $a+b=c$.
+
+$$
+E = mc^2
+$$
+`;
+
+    const { container } = render(Markdown as any, {
+      props: { source, markedInstance, extensionComponents }
+    });
+
+    const inline = container.querySelector('span[data-math="inline"]');
+    expect(inline).toBeTruthy();
+    expect(inline?.textContent).toContain('a+b=c');
+
+    const block = container.querySelector('div[data-math="block"]');
+    expect(block).toBeTruthy();
+    expect(block?.textContent).toContain('E = mc^2');
+  });
+});
+

--- a/packages/tests/renderer/svelte-markdown-override.test.ts
+++ b/packages/tests/renderer/svelte-markdown-override.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { Markdown } from '@markpage/svelte';
+import OverrideCodeSpan from './components/OverrideCodeSpan.svelte';
+
+// Using Svelte component to override built-in codespan
+
+describe('Override built-in token with extensionComponents', () => {
+  it('uses extensionComponents for built-in token type', async () => {
+    const source = 'Inline `code` here';
+
+    const extensionComponents = new Map<string, any>([
+      ['codespan', OverrideCodeSpan]
+    ]);
+
+    const { container } = render(Markdown as any, { props: { source, extensionComponents } });
+
+    const overridden = container.querySelector('code[data-overridden="true"]');
+    expect(overridden).toBeTruthy();
+    expect(overridden?.textContent).toBe('code');
+  });
+});
+


### PR DESCRIPTION
Introduce `extensionComponents` and `unknownToken` props to the Svelte Markdown renderer, enabling custom token rendering and built-in component overrides.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c84e748-63c3-42ae-a821-36dabad53b33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c84e748-63c3-42ae-a821-36dabad53b33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

